### PR TITLE
ui: make app version most prominent

### DIFF
--- a/src/ui/src/app/chart-details/chart-details.component.html
+++ b/src/ui/src/app/chart-details/chart-details.component.html
@@ -14,7 +14,7 @@
           <div class="chart-details__header__text">
             <h1>{{ chart.attributes.name }}</h1>
             <p>
-              <span>{{ chart.relationships.latestChartVersion.data.app_version }}</span> -
+              <span *ngIf="currentVersion && currentVersion.attributes.app_version">{{ currentVersion.attributes.app_version }} -</span>
               <span class="chart-details__header__text__repo">
                 <a [href]="goToRepoUrl()" [routerLink]="goToRepoUrl()">{{ chart.attributes.repo.name }}</a>
               </span><br/>

--- a/src/ui/src/app/chart-details/chart-details.component.html
+++ b/src/ui/src/app/chart-details/chart-details.component.html
@@ -14,7 +14,7 @@
           <div class="chart-details__header__text">
             <h1>{{ chart.attributes.name }}</h1>
             <p>
-              <span>v{{ chart.relationships.latestChartVersion.data.version }}</span> -
+              <span>{{ chart.relationships.latestChartVersion.data.app_version }}</span> -
               <span class="chart-details__header__text__repo">
                 <a [href]="goToRepoUrl()" [routerLink]="goToRepoUrl()">{{ chart.attributes.repo.name }}</a>
               </span><br/>

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -40,9 +40,9 @@ export class ChartDetailsComponent implements OnInit {
           .getVersion(repo, chartName, version)
           .subscribe(chartVersion => {
             this.currentVersion = chartVersion;
+            this.titleVersion = this.currentVersion.attributes.app_version || '';
+            this.updateMetaTags();
           });
-        this.titleVersion = params['version'] || '';
-        this.updateMetaTags();
         this.iconUrl = this.getIconUrl();
       });
     });

--- a/src/ui/src/app/chart-item/chart-item.component.html
+++ b/src/ui/src/app/chart-item/chart-item.component.html
@@ -7,7 +7,7 @@
     </h2>
     <p>
       <span class="chart-item-info__version" *ngIf="showVersion && chart.relationships.latestChartVersion.data.app_version">
-        {{ chart.relationships.latestChartVersion.data.version }}</span>
+        {{ chart.relationships.latestChartVersion.data.app_version }}</span>
       <span class="chart-item-info__repo repo-{{chart.attributes.repo.name}}">
         <a [href]="goToRepoUrl()" [routerLink]="goToRepoUrl()">
           {{ chart.attributes.repo.name }}</a>

--- a/src/ui/src/app/shared/seo.data.ts
+++ b/src/ui/src/app/shared/seo.data.ts
@@ -24,7 +24,7 @@ export default {
                  'Helm Charts'
   },
   details: {
-    title: 'Latest { name } for Kubernetes',
+    title: '{ name } for Kubernetes',
     description: 'Deploy the latest { name } in Kubernetes. { description }'
   },
   detailsWithVersion: {


### PR DESCRIPTION
- fixes #318 - a mistake where the chart version is mistakenly shown instead of the intended app version
- makes the app version more prominent in the chart details page below the name and logo