### PR TITLE
Add support for Traefik as ingress controller

### DIFF
--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -102,10 +102,10 @@ ingress:
     ## Nginx ingress controller (default)
     ingress.kubernetes.io/rewrite-target: /
     kubernetes.io/ingress.class: nginx
-  #  kubernetes.io/tls-acme: 'true'
+    # kubernetes.io/tls-acme: 'true'
     ## Traefik ingress controller
-  #  traefik.frontend.rule.type: PathPrefixStrip
-  #  kubernetes.io/ingress.class: traefik
+    # traefik.frontend.rule.type: PathPrefixStrip
+    # kubernetes.io/ingress.class: traefik
 
   ## Ingress TLS configuration
   ## Secrets must be manually created in the namespace

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -99,9 +99,13 @@ ingress:
   ## Ingress annotations
   ##
   annotations:
+    ## Nginx ingress controller (default)
     ingress.kubernetes.io/rewrite-target: /
     kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: 'true'
+    ## Traefik ingress controller
+  #  traefik.frontend.rule.type: PathPrefixStrip
+  #  kubernetes.io/ingress.class: traefik
 
   ## Ingress TLS configuration
   ## Secrets must be manually created in the namespace


### PR DESCRIPTION
This adds support for Traefik as an Ingress controller

To use it simply comment the nginx annotations and uncomment the traefik annotations.

Tested with Traefik 1.3.3