### PR TITLE
update bitnami/nginx image

### DIFF
--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -17,4 +17,4 @@ compile-aot:
 	npm run compile-aot
 
 docker-build: compile-aot
-	docker build --rm -t ${IMAGE_REPO}:${IMAGE_TAG} rootfs/
+	docker build --pull --rm -t ${IMAGE_REPO}:${IMAGE_TAG} rootfs/

--- a/src/ui/rootfs/Dockerfile
+++ b/src/ui/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/nginx
+FROM bitnami/nginx:1.12
 
 # built by running:
 # $ docker-compose run --rm ui ng build -t production -o rootfs/dist


### PR DESCRIPTION
- the latest image runs as non-root, and has out of the box support on
  OpenShift