### PR TITLE
update nginx internal port to 8080

### DIFF
--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -56,7 +56,7 @@ ui:
     name: monocular-ui
     type: NodePort
     externalPort: 80
-    internalPort: 80
+    internalPort: 8080
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
The updated nginx container runs as non-root so needs to run on a non-privileged port