### PR TITLE
Update Configuring chart repositories section

### DIFF
--- a/deployment/monocular/README.md
+++ b/deployment/monocular/README.md
@@ -67,7 +67,7 @@ You can configure the chart repositories you want to see in Monocular with the `
 
 ```console
 $ cat > custom-repos.yaml <<<EOF
-api
+api:
   config:
     repos:
       - name: stable


### PR DESCRIPTION
I believe the first line after the cat command should have a colon after the word 'api'.  Otherwise, it is not proper yaml format.