### PR TITLE
Fix service name in logs

### DIFF
--- a/src/api/swagger/restapi/server.go
+++ b/src/api/swagger/restapi/server.go
@@ -142,7 +142,7 @@ func (s *Server) Serve() (err error) {
 			if err := domainSocket.Serve(l); err != nil {
 				s.Fatalf("%v", err)
 			}
-			s.Logf("stopped serving todo list at unix://%s", s.SocketPath)
+			s.Logf("stopped serving monocular at unix://%s", s.SocketPath)
 		}(s.domainSocketL)
 	}
 
@@ -159,7 +159,7 @@ func (s *Server) Serve() (err error) {
 			if err := httpServer.Serve(l); err != nil {
 				s.Fatalf("%v", err)
 			}
-			s.Logf("stopped serving todo list at http://%s", l.Addr())
+			s.Logf("stopped serving monocular at http://%s", l.Addr())
 		}(s.httpServerL)
 	}
 
@@ -189,7 +189,7 @@ func (s *Server) Serve() (err error) {
 			if err := httpsServer.Serve(l); err != nil {
 				s.Fatalf("%v", err)
 			}
-			s.Logf("stopped serving todo list at https://%s", l.Addr())
+			s.Logf("stopped serving monocular at https://%s", l.Addr())
 		}(tls.NewListener(s.httpsServerL, httpsServer.TLSConfig))
 	}
 


### PR DESCRIPTION
Certain server operations (e.g. interrupting the server) cause it to
log "todo list" as the server name. Update these log messages.