### PR TITLE
Update CORS logging messages

### DIFF
--- a/src/api/config/cors/cors.go
+++ b/src/api/config/cors/cors.go
@@ -36,11 +36,11 @@ func defaultCors() (Cors, error) {
 func Config(configFile string) (Cors, error) {
 	_, err := os.Stat(configFile)
 	if os.IsNotExist(err) {
-		log.Info("Loading default repositories")
+		log.Info("Loading default CORS config")
 		return defaultCors()
 	}
 
-	log.Info("Loading repositories from config file")
+	log.Info("Loading CORS from config file")
 	cors, err := loadCorsFromFile(configFile)
 	if err != nil {
 		return Cors{}, err


### PR DESCRIPTION
Duplicate logs messages can be found in cors.go and repos.go.
Update the CORS logging messages.