### PR TITLE
provide a configurable namespace where to locate tiller

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -27,6 +27,9 @@ releasesEnabled: true
 # Useful if you are running the app outside of the k8s cluster during development
 tillerPortForward: true
 
+# Specify a different namespace where to locate tiller-deploy
+tillerNamespace: kube-system
+
 # Configure cache refresh interval in sec
 cacheRefreshInterval: 3600
 

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -36,6 +36,7 @@ type Configuration struct {
 	Mongo                datastore.Config `yaml:"mongodb"`
 	OAuthConfig          oauthConfig      `yaml:"oauthConfig"`
 	SigningKey           string           `yaml:"signingKey"`
+	TillerNamespace      string           `yaml:"tillerNamespace"`
 	Initialized          bool
 }
 
@@ -72,6 +73,10 @@ func GetConfig() (Configuration, error) {
 	currentConfig.Repos, err = repos.Enabled(configFilePath)
 	if err != nil {
 		return currentConfig, err
+	}
+
+	if currentConfig.TillerNamespace == "" {
+		currentConfig.TillerNamespace = "kube-system"
 	}
 
 	currentConfig.Initialized = true

--- a/src/api/data/helm/client/client.go
+++ b/src/api/data/helm/client/client.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	tillerNamespace   = "kube-system"
 	tillerServiceName = "tiller-deploy"
 	tillerPort        = 44134
 )
@@ -39,6 +38,11 @@ func NewHelmClient() data.Client {
 // InitializeClient returns a helm.client
 func (c *helmClient) initialize() (*helm.Client, error) {
 	// From helm.setupConnection
+	conf, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	tillerNamespace := conf.TillerNamespace
 	var tillerHost = fmt.Sprintf("%s.%s:%d", tillerServiceName, tillerNamespace, tillerPort)
 
 	if c.portForward {


### PR DESCRIPTION
as of today, monocular wont be able to connect to a tiller-deploy running outside of the kube-system namespace.
so we provide the ability to use a specific namespace from the config file