### PR TITLE
Adds JWT Auth mechanmism using GitHub Oauth

### DIFF
--- a/dev_env/api/Dockerfile
+++ b/dev_env/api/Dockerfile
@@ -3,14 +3,12 @@ FROM quay.io/deis/go-dev:v0.22.0
 MAINTAINER Miguel Martinez <miguel@bitnami.com>
 
 RUN curl https://glide.sh/get | sh
+RUN go get github.com/codegangsta/gin
 
 COPY rootfs/ /
 
 WORKDIR /go/src/github.com/kubernetes-helm/monocular/src/api
 
-ENV HOST=0.0.0.0
-ENV PORT=8080
-
 ENTRYPOINT ["/app-entrypoint.sh"]
 
-CMD ["go", "run", "main.go"]
+CMD ["gin", "-i", "run", "main.go"]

--- a/dev_env/api/rootfs/app-entrypoint.sh
+++ b/dev_env/api/rootfs/app-entrypoint.sh
@@ -13,13 +13,18 @@ dependencies_up_to_date() {
   [ ! $PACKAGE_FILE -nt $INIT_SEM ]
 }
 
-if [ "$1" == "go" -a "$2" == "run" ]; then
+if [ "$1" == "gin" -a "$3" == "run" ]; then
 	if ! dependencies_up_to_date; then
 		log "Packages updating..."
 		glide install
 		log "Packages updated"
 	fi
   touch $INIT_SEM
+
+  # Set env vars if .env file exists
+  if [ -f .env ]; then
+    export $(egrep -v '^#' .env | xargs)
+  fi
 fi
 
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     tty: true
     build: ./dev_env/api
     ports:
-    - 8080:8080
+    - 8080:3000
     volumes:
       - ./src/api:/go/src/github.com/kubernetes-helm/monocular/src/api
       # Config example file

--- a/src/api/.gitignore
+++ b/src/api/.gitignore
@@ -1,1 +1,2 @@
 monocular
+gin-bin

--- a/src/api/.gitignore
+++ b/src/api/.gitignore
@@ -1,2 +1,3 @@
 monocular
 gin-bin
+.env

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"golang.org/x/oauth2"
+	oauth2Github "golang.org/x/oauth2/github"
 	yaml "gopkg.in/yaml.v2"
 
 	log "github.com/Sirupsen/logrus"
@@ -74,6 +77,34 @@ func GetConfig() (Configuration, error) {
 
 	log.Info("Configuration bootstrap finished")
 	return currentConfig, nil
+}
+
+// GetOAuthConfig returns the OAuth configuration for the GitHub provider
+func GetOAuthConfig(host string) (*oauth2.Config, error) {
+	clientID, ok := os.LookupEnv("MONOCULAR_AUTH_GITHUB_CLIENT_ID")
+	if !ok {
+		return nil, errors.New("no client ID for GitHub provider, ensure MONOCULAR_AUTH_GITHUB_CLIENT_ID is set")
+	}
+	clientSecret, ok := os.LookupEnv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET")
+	if !ok {
+		return nil, errors.New("no client secret for GitHub provider, ensure MONOCULAR_AUTH_GITHUB_CLIENT_SECRET is set")
+	}
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Endpoint:     oauth2Github.Endpoint,
+		RedirectURL:  "http://" + host + "/auth/github/callback",
+		Scopes:       []string{"repo"},
+	}, nil
+}
+
+// GetAuthSigningKey returns the secret key used for signing JWTs and secure sessions
+func GetAuthSigningKey() (string, error) {
+	signingKey, ok := os.LookupEnv("MONOCULAR_AUTH_SIGNING_KEY")
+	if !ok {
+		return "", errors.New("no signing key, ensure MONOCULAR_AUTH_SIGNING_KEY is set")
+	}
+	return signingKey, nil
 }
 
 // BaseDir returns the location of the directory

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -16,6 +16,11 @@ import (
 // and environment specific ones
 type configurationWithOverrides map[string]Configuration
 
+type oauthConfig struct {
+	ClientID     string `yaml:"clientID"`
+	ClientSecret string `yaml:"clientSecret"`
+}
+
 // Configuration is the the resulting environment based Configuration
 // For now it only includes Cors info
 type Configuration struct {
@@ -25,6 +30,8 @@ type Configuration struct {
 	TillerPortForward    bool  `yaml:"tillerPortForward"`
 	CacheRefreshInterval int64 `yaml:"cacheRefreshInterval"`
 	Redis                redisConfig
+	OAuthConfig          oauthConfig `yaml:"oauthConfig"`
+	SigningKey           string      `yaml:"signingKey"`
 	Initialized          bool
 }
 

--- a/src/api/config/config_test.go
+++ b/src/api/config/config_test.go
@@ -91,3 +91,64 @@ func TestConfigFile(t *testing.T) {
 	path := filepath.Join(BaseDir(), "config", "monocular.yaml")
 	assert.Equal(t, configFile(), path, "Config file = BaseDir + config + monocular.yaml")
 }
+
+func TestGetOAuthConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientIDSet     bool
+		clientSecretSet bool
+		wantErr         bool
+	}{
+		{"no client ID or secret", false, false, true},
+		{"no client ID", false, true, true},
+		{"no client secret", true, false, true},
+		{"both client ID and secret", true, true, false},
+	}
+	expectedClientID := "clientID"
+	expectedClientSecret := "clientSecret"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.clientIDSet {
+				os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID", expectedClientID)
+				defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID")
+			}
+			if tt.clientSecretSet {
+				os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET", expectedClientSecret)
+				defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET")
+			}
+			got, err := GetOAuthConfig("monocular.local")
+			if tt.wantErr {
+				assert.ExistsErr(t, err, tt.name)
+			} else {
+				assert.NotNil(t, got, "oauth config")
+				assert.Equal(t, got.ClientID, expectedClientID, "client ID")
+				assert.Equal(t, got.ClientSecret, expectedClientSecret, "client secret")
+			}
+		})
+	}
+}
+
+func TestGetAuthSigningKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		set     bool
+		want    string
+		wantErr bool
+	}{
+		{"no signing key", false, "", true},
+		{"signing key", true, "secret", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				os.Setenv("MONOCULAR_AUTH_SIGNING_KEY", tt.want)
+				defer os.Unsetenv("MONOCULAR_AUTH_SIGNING_KEY")
+			}
+			got, err := GetAuthSigningKey()
+			if tt.wantErr {
+				assert.ExistsErr(t, err, tt.name)
+			}
+			assert.Equal(t, got, tt.want, "signing key")
+		})
+	}
+}

--- a/src/api/glide.lock
+++ b/src/api/glide.lock
@@ -1,5 +1,5 @@
-hash: 2108ae1782273e29383d5e89a8b6cdbfde783a5fb86cfd8893d17d4165cdee55
-updated: 2017-09-20T09:09:12.686523429Z
+hash: fb3095a0b012b329bbc3ac5e1838ce35f2b70b719c614724c3fdf4903999dfea
+updated: 2017-09-22T10:34:09.936749196Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -101,7 +101,7 @@ imports:
 - name: github.com/facebookgo/symwalk
   version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/garyburd/redigo
-  version: 9e66b83d15a259978be267d0b61838c42c3904e3
+  version: b8dc90050f24c1a73a52f107f3f575be67b21b7c
   subpackages:
   - internal
   - redis
@@ -145,8 +145,6 @@ imports:
   - syntax/lexer
   - util/runes
   - util/strings
-- name: github.com/gocraft/work
-  version: 2a383f87e013a086dac00a8d4a8138c909d2bd17
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
@@ -187,20 +185,30 @@ imports:
   - proto
   - ptypes/any
   - ptypes/timestamp
+- name: github.com/google/go-github
+  version: 61bf8a6a2009b7fb88173ed454c77fb8013b8852
+  subpackages:
+  - github
+- name: github.com/google/go-querystring
+  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
+  subpackages:
+  - query
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+- name: github.com/gorilla/securecookie
+  version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
+- name: github.com/gorilla/sessions
+  version: b61c93cb7f67533c8bfbb5ea450efc07e5833c5e
 - name: github.com/howeyc/gopass
   version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 3e95a51e0639b4cf372f2ccf74c86749d747fbdc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/jessevdk/go-flags
-  version: 4e64e4a4e2552194cf594243e23aa9baf3b4297e
 - name: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
@@ -225,8 +233,6 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/robfig/cron
-  version: 736158dc09e10f1911ca3a1e1b01f11b566ce5db
 - name: github.com/rs/cors
   version: a62a804a8a009876ca59105f7899938a1349f4b3
 - name: github.com/rs/xhandler
@@ -239,8 +245,6 @@ imports:
   version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/tv42/base58
   version: b6649477bfe6276322b4eeaae8f5e947b49cec92
-- name: github.com/tylerb/graceful
-  version: 4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb
 - name: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
@@ -281,6 +285,7 @@ imports:
 - name: golang.org/x/oauth2
   version: 3c3a985cb79f52a3190fbc056984415ca6763d01
   subpackages:
+  - github
   - google
   - internal
   - jws

--- a/src/api/glide.yaml
+++ b/src/api/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/kubernetes-helm/monocular
 import:
 - package: github.com/gorilla/mux
+- package: github.com/gorilla/sessions
 - package: github.com/kelseyhightower/envconfig
 - package: github.com/arschles/assert
 - package: github.com/go-openapi/runtime
@@ -60,7 +61,18 @@ import:
 - package: github.com/albrow/zoom
   version: ~0.18.0
 - package: github.com/dchest/uniuri
-- package: github.com/garyburd/redigo/redis
+- package: github.com/garyburd/redigo
+  subpackages:
+  - redis
 - package: github.com/tv42/base58
 - package: github.com/urfave/negroni
 - package: github.com/unrolled/render
+- package: github.com/dgrijalva/jwt-go
+- package: golang.org/x/oauth2
+- package: github.com/google/go-github
+  subpackages:
+  - github
+- package: github.com/gorilla/securecookie
+- package: github.com/google/go-querystring
+  subpackages:
+  - query

--- a/src/api/handlers/auth.go
+++ b/src/api/handlers/auth.go
@@ -123,7 +123,7 @@ func (a *AuthHandlers) GithubCallback(w http.ResponseWriter, r *http.Request) {
 
 // Logout clears the JWT token cookie
 func (a *AuthHandlers) Logout(w http.ResponseWriter, r *http.Request) {
-	cookie := http.Cookie{Name: "ka_auth", Value: "", Path: "/", Expires: time.Unix(0, 0)}
+	cookie := http.Cookie{Name: "ka_auth", Value: "", Path: "/", Expires: time.Unix(1, 0)}
 	http.SetCookie(w, &cookie)
 }
 

--- a/src/api/handlers/auth.go
+++ b/src/api/handlers/auth.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/google/go-github/github"
+	"github.com/kubernetes-helm/monocular/src/api/data/pointerto"
+
+	"github.com/gorilla/sessions"
+	"github.com/kubernetes-helm/monocular/src/api/config"
+	"github.com/kubernetes-helm/monocular/src/api/handlers/renderer"
+	"github.com/kubernetes-helm/monocular/src/api/swagger/models"
+	"golang.org/x/oauth2"
+	oauth2Github "golang.org/x/oauth2/github"
+)
+
+type userClaims struct {
+	Name  string
+	Email string
+	jwt.StandardClaims
+}
+
+// AuthHandlers defines handlers that provide authentication
+type AuthHandlers struct {
+	store sessions.Store
+	conf  config.Configuration
+}
+
+// NewAuthHandlers takes a sessions.Store implementation and returns an AuthHandlers struct
+func NewAuthHandlers(s sessions.Store, c config.Configuration) *AuthHandlers {
+	return &AuthHandlers{s, c}
+}
+
+// InitiateOAuth initiatates an OAuth request
+func (a *AuthHandlers) InitiateOAuth(w http.ResponseWriter, r *http.Request) {
+	state := randomStr()
+	session, _ := a.store.Get(r, "sess")
+	session.Values["state"] = state
+	session.Save(r, w)
+
+	url := oauthConfig(a.conf, r.Host).AuthCodeURL(state)
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+// GithubCallback processes the OAuth callback from GitHub
+func (a *AuthHandlers) GithubCallback(w http.ResponseWriter, r *http.Request) {
+	session, err := a.store.Get(r, "sess")
+	if err != nil {
+		errorResponse(w, http.StatusBadRequest, "invalid session")
+		return
+	}
+
+	if r.URL.Query().Get("state") != session.Values["state"] {
+		errorResponse(w, http.StatusBadRequest, "no state match - possible CSRF or cookies not enabled")
+		return
+	}
+
+	tkn, err := oauthConfig(a.conf, r.Host).Exchange(oauth2.NoContext, r.URL.Query().Get("code"))
+	if err != nil {
+		errorResponse(w, http.StatusBadRequest, "unable to get access token")
+		return
+	}
+
+	if !tkn.Valid() {
+		errorResponse(w, http.StatusInternalServerError, "invalid access token retrieved")
+		return
+	}
+
+	client := github.NewClient(oauthConfig(a.conf, r.Host).Client(oauth2.NoContext, tkn))
+
+	user, _, err := client.Users.Get(oauth2.NoContext, "")
+	if err != nil {
+		errorResponse(w, http.StatusInternalServerError, "unable to retrieve user")
+		return
+	}
+
+	claims := userClaims{
+		*user.Name,
+		*user.Email,
+		jwt.StandardClaims{
+			ExpiresAt: tokenExpiration().Unix(),
+			Issuer:    r.Host,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, _ := token.SignedString([]byte(a.conf.SigningKey))
+	jwtCookie := http.Cookie{Name: "ka_auth", Value: signedToken, Path: "/", Expires: tokenExpiration(), HttpOnly: true}
+
+	jsonClaims, err := json.Marshal(claims)
+	if err != nil {
+		errorResponse(w, http.StatusInternalServerError, "error marshalling claims")
+		return
+	}
+	claimsCookie := http.Cookie{Name: "ka_claims", Value: string(jsonClaims), Path: "/"}
+
+	http.SetCookie(w, &jwtCookie)
+	http.SetCookie(w, &claimsCookie)
+
+	http.Redirect(w, r, r.Referer(), http.StatusFound)
+}
+
+func tokenExpiration() time.Time {
+	return time.Now().Add(time.Hour * 2)
+}
+
+func oauthConfig(c config.Configuration, host string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     c.OAuthConfig.ClientID,
+		ClientSecret: c.OAuthConfig.ClientSecret,
+		Endpoint:     oauth2Github.Endpoint,
+		RedirectURL:  "http://" + host + "/auth/github/callback",
+		Scopes:       []string{"repo"},
+	}
+}
+
+func randomStr() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	state := base64.URLEncoding.EncodeToString(b)
+	return state
+}
+
+func errorResponse(w http.ResponseWriter, code int, message string) {
+	renderer.Render.JSON(w, code, models.Error{Code: pointerto.Int64(int64(code)), Message: &message})
+}

--- a/src/api/handlers/auth_test.go
+++ b/src/api/handlers/auth_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/gorilla/sessions"
+	"github.com/kubernetes-helm/monocular/src/api/swagger/models"
+	"github.com/kubernetes-helm/monocular/src/api/testutil"
+)
+
+func TestNewAuthHandlers(t *testing.T) {
+	tests := []struct {
+		name          string
+		setSigningKey bool
+		wantErr       bool
+	}{
+		{"no signing key", false, true},
+		{"signing key", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setSigningKey {
+				os.Setenv("MONOCULAR_AUTH_SIGNING_KEY", "secret")
+				defer os.Unsetenv("MONOCULAR_AUTH_SIGNING_KEY")
+			}
+			got, err := NewAuthHandlers()
+			if tt.wantErr {
+				assert.ExistsErr(t, err, "NewAuthHandlers error")
+				assert.Nil(t, got, "returned AuthHandlers")
+				return
+			}
+			assert.Equal(t, got.signingKey, "secret", "signing key")
+		})
+	}
+}
+
+func TestAuthHandlers_InitiateOAuth(t *testing.T) {
+	s := sessions.NewCookieStore([]byte("secret"))
+	ah := &AuthHandlers{"secret", s}
+	os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID", "clientid")
+	defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID")
+	os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET", "clientsecret")
+	defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET")
+
+	req, err := http.NewRequest("GET", "/auth", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	ah.InitiateOAuth(res, req)
+
+	assert.Equal(t, res.Code, http.StatusFound, "response code")
+
+	session, err := s.Get(req, "ka_sess")
+	assert.NoErr(t, err)
+	_, ok := session.Values["state"]
+	assert.True(t, ok, "expected state to be set in session")
+
+	location := res.Header().Get("Location")
+	assert.True(t, location != "", "expected Location header to be set")
+}
+
+func TestAuthHandlers_InitiateOAuthForbidden(t *testing.T) {
+	s := sessions.NewCookieStore([]byte("secret"))
+	ah := &AuthHandlers{"secret", s}
+	req, err := http.NewRequest("GET", "/auth", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	ah.InitiateOAuth(res, req)
+	assert.Equal(t, res.Code, http.StatusForbidden, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
+	assert.NotNil(t, httpBody.Message, "error response")
+	assert.Equal(t, *httpBody.Code, int64(http.StatusForbidden), "response code in HTTP body data")
+	assert.True(t, strings.Contains(*httpBody.Message, "auth service not enabled"), "error message in HTTP body data")
+}
+
+func TestAuthHandlers_GithubCallbackStateMismatch(t *testing.T) {
+	s := sessions.NewCookieStore([]byte("secret"))
+	ah := &AuthHandlers{"secret", s}
+	os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID", "clientid")
+	defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_ID")
+	os.Setenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET", "clientsecret")
+	defer os.Unsetenv("MONOCULAR_AUTH_GITHUB_CLIENT_SECRET")
+
+	req, err := http.NewRequest("GET", "/auth/github/callback", nil)
+	assert.NoErr(t, err)
+	state := "state"
+	session, err := s.Get(req, "ka_sess")
+	assert.NoErr(t, err)
+	session.Values["state"] = state
+
+	res := httptest.NewRecorder()
+	ah.GithubCallback(res, req)
+
+	assert.Equal(t, res.Code, http.StatusBadRequest, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
+	assert.NotNil(t, httpBody.Message, "error response")
+	assert.Equal(t, *httpBody.Code, int64(http.StatusBadRequest), "response code in HTTP body data")
+	assert.True(t, strings.Contains(*httpBody.Message, "no state match"), "error message in HTTP body data")
+}
+
+func TestAuthHandlers_GithubCallbackForbidden(t *testing.T) {
+	s := sessions.NewCookieStore([]byte("secret"))
+	ah := &AuthHandlers{"secret", s}
+
+	req, err := http.NewRequest("GET", "/auth/github/callback", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	ah.GithubCallback(res, req)
+
+	assert.Equal(t, res.Code, http.StatusForbidden, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
+	assert.NotNil(t, httpBody.Message, "error response")
+	assert.Equal(t, *httpBody.Code, int64(http.StatusForbidden), "response code in HTTP body data")
+	assert.True(t, strings.Contains(*httpBody.Message, "auth service not enabled"), "error message in HTTP body data")
+}
+
+func TestAuthHandlers_Logout(t *testing.T) {
+	s := sessions.NewCookieStore([]byte("secret"))
+	ah := &AuthHandlers{"secret", s}
+
+	req, err := http.NewRequest("DELETE", "/auth/logout", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	ah.Logout(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK, "response code")
+	header := res.Header().Get("Set-Cookie")
+	assert.Equal(t, header, "ka_auth=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT", "header")
+}
+
+func Test_tokenExpiration(t *testing.T) {
+	expectedHour := (time.Now().Hour() + 2) % 24
+	assert.Equal(t, tokenExpiration().Hour(), expectedHour, "hour")
+}
+
+func Test_randomStr(t *testing.T) {
+	s1 := randomStr()
+	s2 := randomStr()
+	assert.True(t, s1 != s2, "expected %s to not equal %s", s1, s2)
+}
+
+func Test_errorResponse(t *testing.T) {
+	message := "error message"
+	res := httptest.NewRecorder()
+	errorResponse(res, http.StatusBadRequest, message)
+	assert.Equal(t, res.Code, http.StatusBadRequest, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
+	assert.Equal(t, *httpBody.Code, int64(http.StatusBadRequest), "response code in body")
+	assert.Equal(t, *httpBody.Message, message, "error message in body")
+}

--- a/src/api/main_test.go
+++ b/src/api/main_test.go
@@ -35,7 +35,7 @@ var conf, _ = config.GetConfig()
 
 // tests the GET /healthz endpoint
 func TestGetHealthz(t *testing.T) {
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 
 	res, err := http.Get(ts.URL + "/healthz")
@@ -48,7 +48,7 @@ func TestGetHealthz(t *testing.T) {
 func TestGetCharts(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	charts, err := chartsImplementation.All()
 	assert.NoErr(t, err)
@@ -65,7 +65,7 @@ func TestGetCharts(t *testing.T) {
 func TestGetChartsInRepo200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	charts, err := chartsImplementation.AllFromRepo(testutil.RepoName)
 	numCharts := len(helpers.MakeChartResources(charts))
@@ -83,7 +83,7 @@ func TestGetChartsInRepo200(t *testing.T) {
 func TestGetChartsInRepo404(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", handlerscharts.ChartResourceName+"s", testutil.BogusRepo))
 	assert.NoErr(t, err)
@@ -98,7 +98,7 @@ func TestGetChartsInRepo404(t *testing.T) {
 func TestGetChartInRepo200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	chart, err := chartsImplementation.ChartFromRepo(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
@@ -116,7 +116,7 @@ func TestGetChartInRepo200(t *testing.T) {
 func TestGetChartInRepo404(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", handlerscharts.ChartResourceName+"s", testutil.BogusRepo, testutil.ChartName))
 	assert.NoErr(t, err)
@@ -131,7 +131,7 @@ func TestGetChartInRepo404(t *testing.T) {
 func TestGetChartVersion200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	chart, err := chartsImplementation.ChartVersionFromRepo(testutil.RepoName, testutil.ChartName, testutil.ChartVersionString)
 	assert.NoErr(t, err)
@@ -149,7 +149,7 @@ func TestGetChartVersion200(t *testing.T) {
 func TestGetChartVersion404(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", handlerscharts.ChartResourceName+"s", testutil.RepoName, testutil.ChartName, versionsRouteString, "99.99.99"))
 	assert.NoErr(t, err)
@@ -164,7 +164,7 @@ func TestGetChartVersion404(t *testing.T) {
 func TestGetChartVersions200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	charts, err := chartsImplementation.ChartVersionsFromRepo(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
@@ -181,7 +181,7 @@ func TestGetChartVersions200(t *testing.T) {
 func TestGetChartVersions404(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", handlerscharts.ChartResourceName+"s", testutil.BogusRepo, testutil.ChartName, versionsRouteString))
 	assert.NoErr(t, err)
@@ -196,7 +196,7 @@ func TestGetChartVersions404(t *testing.T) {
 func TestGetRepos200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "repos"))
 	assert.NoErr(t, err)
@@ -214,7 +214,7 @@ func TestCreateRepo201(t *testing.T) {
 	defer teardownTestRepoCache()
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	repoName := "repoName"
 	testRepo := models.Repo{
@@ -239,7 +239,7 @@ func TestCreateRepo201(t *testing.T) {
 func TestCreateRepo403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	repoName := "repoName"
 	testRepo := models.Repo{
@@ -263,7 +263,7 @@ func TestCreateRepo403(t *testing.T) {
 func TestGetRepo200(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "repos", testutil.RepoName))
 	assert.NoErr(t, err)
@@ -280,7 +280,7 @@ func TestDeleteRepo200(t *testing.T) {
 	defer teardownTestRepoCache()
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	req, err := http.NewRequest("DELETE", urlPath(ts.URL, "v1", "repos", testutil.RepoName), nil)
 	assert.NoErr(t, err)
@@ -300,7 +300,7 @@ func TestDeleteRepo200(t *testing.T) {
 func TestDeleteRepo403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	req, err := http.NewRequest("DELETE", urlPath(ts.URL, "v1", "repos", testutil.RepoName), nil)
 	assert.NoErr(t, err)
@@ -323,7 +323,7 @@ func TestGetReleases200(t *testing.T) {
 	defer teardownTestRepoCache()
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "releases"))
 	assert.NoErr(t, err)
@@ -335,7 +335,7 @@ func TestGetReleases200(t *testing.T) {
 func TestGetReleases403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "releases"))
 	assert.NoErr(t, err)
@@ -353,7 +353,7 @@ func TestCreateRelease201(t *testing.T) {
 	defer teardownTestRepoCache()
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	chartID := fmt.Sprintf("%s/%s", testutil.RepoName, testutil.ChartName)
 	params := releasesapi.CreateReleaseBody{
@@ -372,7 +372,7 @@ func TestCreateRelease201(t *testing.T) {
 func TestCreateRelease403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	chartID := fmt.Sprintf("%s/%s", testutil.RepoName, testutil.ChartName)
 	params := releasesapi.CreateReleaseBody{
@@ -398,7 +398,7 @@ func TestGetRelease200(t *testing.T) {
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
 	releaseName := "foo"
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "releases", releaseName))
 	assert.NoErr(t, err)
@@ -411,7 +411,7 @@ func TestGetRelease403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
 	releaseName := "foo"
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	res, err := http.Get(urlPath(ts.URL, "v1", "releases", releaseName))
 	assert.NoErr(t, err)
@@ -430,7 +430,7 @@ func TestDeleteRelease200(t *testing.T) {
 	conf.ReleasesEnabled = true
 	defer func() { conf.ReleasesEnabled = false }()
 	releaseName := "foo"
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	req, err := http.NewRequest("DELETE", urlPath(ts.URL, "v1", "releases", releaseName), nil)
 	assert.NoErr(t, err)
@@ -446,7 +446,7 @@ func TestDeleteRelease403(t *testing.T) {
 	setupTestRepoCache()
 	defer teardownTestRepoCache()
 	releaseName := "foo"
-	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient, sessionStore))
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
 	defer ts.Close()
 	req, err := http.NewRequest("DELETE", urlPath(ts.URL, "v1", "releases", releaseName), nil)
 	assert.NoErr(t, err)

--- a/src/api/main_test.go
+++ b/src/api/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -459,6 +460,39 @@ func TestDeleteRelease403(t *testing.T) {
 	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
 	assert.Equal(t, *httpBody.Code, int64(http.StatusForbidden), "response code in HTTP body data")
 	assert.Equal(t, *httpBody.Message, "feature not enabled", "error message")
+}
+
+func TestAuthGatedRoutes(t *testing.T) {
+	setupTestRepoCache()
+	defer teardownTestRepoCache()
+	os.Setenv("MONOCULAR_AUTH_SIGNING_KEY", "secret")
+	defer os.Unsetenv("MONOCULAR_AUTH_SIGNING_KEY")
+	conf.ReleasesEnabled = true
+	defer func() { conf.ReleasesEnabled = false }()
+	ts := httptest.NewServer(setupRoutes(conf, chartsImplementation, helmClient))
+	defer ts.Close()
+	tests := []struct {
+		method string
+		route  string
+	}{
+		// Repos
+		{"POST", "/repos"},
+		{"DELETE", "/repos/stable"},
+		// Releases
+		{"GET", "/releases"},
+		{"POST", "/releases"},
+		{"GET", "/releases/cold-hands"},
+		{"DELETE", "/releases/cold-hands"},
+	}
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, ts.URL+"/v1"+tt.route, nil)
+		assert.NoErr(t, err)
+		client := http.Client{}
+		res, err := client.Do(req)
+		assert.NoErr(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, res.StatusCode, http.StatusUnauthorized, "response code")
+	}
 }
 
 func urlPath(ver string, remainder ...string) string {

--- a/src/api/middleware/authgate.go
+++ b/src/api/middleware/authgate.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/kubernetes-helm/monocular/src/api/config"
+	"github.com/kubernetes-helm/monocular/src/api/data/pointerto"
+	"github.com/urfave/negroni"
+
+	"github.com/kubernetes-helm/monocular/src/api/handlers/renderer"
+	"github.com/kubernetes-helm/monocular/src/api/swagger/models"
+)
+
+type contextKey int
+
+const userKey contextKey = 0
+
+type userClaims struct {
+	Name  string
+	Email string
+	jwt.StandardClaims
+}
+
+// AuthGate implements middleware to check if the user is logged in before continuing
+func AuthGate(c config.Configuration) negroni.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		if c.OAuthConfig.ClientID == "" || c.OAuthConfig.ClientSecret == "" || c.SigningKey == "" {
+			next(w, req)
+			return
+		}
+		cookie, err := req.Cookie("ka_auth")
+		if err != nil {
+			unauthorizedResponse(w)
+			return
+		}
+
+		token, err := jwt.ParseWithClaims(cookie.Value, &userClaims{}, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(c.SigningKey), nil
+		})
+		if err != nil {
+			unauthorizedResponse(w)
+			return
+		}
+
+		if claims, ok := token.Claims.(*userClaims); ok && token.Valid {
+			ctx := context.WithValue(req.Context(), userKey, *claims)
+			next(w, req.WithContext(ctx))
+		} else {
+			unauthorizedResponse(w)
+		}
+	}
+}
+
+func unauthorizedResponse(w http.ResponseWriter) {
+	renderer.Render.JSON(w, http.StatusUnauthorized, models.Error{
+		Code:    pointerto.Int64(int64(http.StatusUnauthorized)),
+		Message: pointerto.String("not logged in"),
+	})
+}

--- a/src/api/middleware/authgate_test.go
+++ b/src/api/middleware/authgate_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/kubernetes-helm/monocular/src/api/swagger/models"
+	"github.com/kubernetes-helm/monocular/src/api/testutil"
+)
+
+var handler = func(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestAuthGate(t *testing.T) {
+	tests := []struct {
+		name   string
+		cookie http.Cookie
+		want   int
+	}{
+		{"no cookie", http.Cookie{}, http.StatusUnauthorized},
+		{"unparseable JWT", http.Cookie{Name: "ka_auth", Value: "unparseable", Path: "/"}, http.StatusUnauthorized},
+		{"expired JWT", generateJWT(generateClaims(time.Now().Add(-time.Hour * 2))), http.StatusUnauthorized},
+		{"valid JWT", generateJWT(generateClaims(time.Now().Add(time.Hour * 2))), http.StatusOK},
+	}
+
+	os.Setenv("MONOCULAR_AUTH_SIGNING_KEY", "secret")
+	defer os.Unsetenv("MONOCULAR_AUTH_SIGNING_KEY")
+	for _, tt := range tests {
+		req, err := http.NewRequest("GET", "/auth-gate", nil)
+		assert.NoErr(t, err)
+		req.AddCookie(&tt.cookie)
+		res := httptest.NewRecorder()
+		AuthGate()(res, req, handler)
+		assert.Equal(t, res.Code, tt.want, tt.name)
+	}
+}
+
+func TestAuthGateDisabled(t *testing.T) {
+	req, err := http.NewRequest("GET", "/auth-gate", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	AuthGate()(res, req, handler)
+	assert.Equal(t, res.Code, http.StatusOK, "response code")
+}
+
+func generateClaims(expiresAt time.Time) jwt.Claims {
+	return userClaims{
+		"Jon Snow",
+		"jonsnow@winteriscoming.io",
+		jwt.StandardClaims{
+			ExpiresAt: expiresAt.Unix(),
+			Issuer:    "lyanna.stark",
+		},
+	}
+}
+
+func generateJWT(claims jwt.Claims) http.Cookie {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, _ := token.SignedString([]byte("secret"))
+	return http.Cookie{Name: "ka_auth", Value: signedToken, Path: "/", HttpOnly: true}
+}
+
+func Test_unauthorizedResponse(t *testing.T) {
+	res := httptest.NewRecorder()
+	unauthorizedResponse(res)
+	assert.Equal(t, res.Code, http.StatusUnauthorized, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(res.Body, &httpBody))
+	assert.Equal(t, *httpBody.Code, int64(http.StatusUnauthorized), "response code in body")
+	assert.Equal(t, *httpBody.Message, "not logged in", "error message in body")
+}

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -41,6 +41,7 @@
     "intl": "^1.2.5",
     "marked": "^0.3.6",
     "ngx-clipboard": "^8.0.3",
+    "ngx-cookie": "^1.0.0",
     "rxjs": "^5.1.0",
     "url-join": "^2.0.2",
     "zone.js": "^0.8.4"

--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {
   MetaStaticLoader,
   PageTitlePositioning
 } from '@ngx-meta/core';
+import { CookieModule } from 'ngx-cookie';
 import { routing, appRoutingProviders } from './app.routing';
 
 /* Material library */
@@ -115,7 +116,8 @@ export function metaFactory(): MetaLoader {
     MetaModule.forRoot({
       provide: MetaLoader,
       useFactory: metaFactory
-    })
+    }),
+    CookieModule.forRoot()
   ],
   providers: [
     appRoutingProviders,

--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { ConfigService } from './shared/services/config.service';
 import { MenuService } from './shared/services/menu.service';
 import { DialogsService } from './shared/services/dialogs.service';
 import { SeoService } from './shared/services/seo.service';
+import { AuthService } from './shared/services/auth.service';
 
 /* Components */
 import { AppComponent } from './app.component';
@@ -127,7 +128,8 @@ export function metaFactory(): MetaLoader {
     ConfigService,
     MenuService,
     SeoService,
-    DialogsService
+    DialogsService,
+    AuthService,
   ],
   entryComponents: [
     ConfirmDialog,

--- a/src/ui/src/app/header-bar/header-bar.component.html
+++ b/src/ui/src/app/header-bar/header-bar.component.html
@@ -15,23 +15,29 @@
         </li>
         <li *ngIf="showSearch" class="separator"></li>
         <li routerLink="/charts" routerLinkActive="active">
-          <a class="reverse" >
+          <a class="reverse">
             Charts
           </a>
         </li>
-        <li class="separator"></li>
-        <li *ngIf="config.releasesEnabled" routerLink="/repos" routerLinkActive="active">
+        <li *ngIf="!loggedIn" class="separator"></li>
+        <li *ngIf="!loggedIn">
+          <a class="reverse" href="{{config.backendHostname}}/auth">
+            Login with GitHub
+          </a>
+        </li>
+        <li *ngIf="loggedIn && config.releasesEnabled" class="separator"></li>
+        <li *ngIf="loggedIn && config.releasesEnabled" routerLink="/repos" routerLinkActive="active">
           <a class="reverse">
             Repositories
           </a>
         </li>
-        <li *ngIf="config.releasesEnabled" class="separator"></li>
-        <li *ngIf="config.releasesEnabled" routerLink="/deployments" routerLinkActive="active">
+        <li *ngIf="loggedIn && config.releasesEnabled" class="separator"></li>
+        <li *ngIf="loggedIn && config.releasesEnabled" routerLink="/deployments" routerLinkActive="active">
           <a class="reverse">
             Deployments
           </a>
         </li>
-        <li *ngIf="config.releasesEnabled" class="separator"></li>
+        <li class="separator"></li>
         <li>
           <a class="reverse" href="https://github.com/kubernetes-helm/monocular/blob/master/docs/about.md" target="_blank">
             About

--- a/src/ui/src/app/header-bar/header-bar.component.html
+++ b/src/ui/src/app/header-bar/header-bar.component.html
@@ -43,6 +43,13 @@
             About
           </a>
         </li>
+        <li *ngIf="loggedIn && user.Email" class="separator"></li>
+        <li *ngIf="loggedIn && user.Email">
+          {{ user.Email }}
+          <a class="reverse" (click)="logout()" target="_blank">
+            (logout)
+          </a>
+        </li>
       </ul>
     </nav>
     <nav class="header-bar__open" [class.opened]="openedMenu">

--- a/src/ui/src/app/header-bar/header-bar.component.scss
+++ b/src/ui/src/app/header-bar/header-bar.component.scss
@@ -43,6 +43,7 @@ $header-bar-padding-small: 0 2em;
   &__navigation {
     margin-left: auto;
     display: none;
+    color: $text-white;
 
     ul {
       margin: .5em 0;

--- a/src/ui/src/app/header-bar/header-bar.component.ts
+++ b/src/ui/src/app/header-bar/header-bar.component.ts
@@ -20,7 +20,7 @@ export class HeaderBarComponent implements OnInit {
   // Whether or not the Monocular server requires authentication
   public loggedIn: boolean = false;
   // public user
-  public user: object = {};
+  public user: any = {};
   // Show search form by default
   public showSearch: boolean = true;
   // Set the background as transparent

--- a/src/ui/src/app/header-bar/header-bar.component.ts
+++ b/src/ui/src/app/header-bar/header-bar.component.ts
@@ -6,6 +6,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { MdIconRegistry } from '@angular/material';
 import { MdSnackBar } from '@angular/material';
 import { CookieService } from 'ngx-cookie';
+import { AuthService } from '../shared/services/auth.service';
 
 @Component({
   selector: 'app-header-bar',
@@ -16,8 +17,10 @@ import { CookieService } from 'ngx-cookie';
   inputs: ['showSearch', 'transparent']
 })
 export class HeaderBarComponent implements OnInit {
-  // public loggedIn
-  public loggedIn: boolean;
+  // Whether or not the Monocular server requires authentication
+  public loggedIn: boolean = false;
+  // public user
+  public user: object = {};
   // Show search form by default
   public showSearch: boolean = true;
   // Set the background as transparent
@@ -34,6 +37,7 @@ export class HeaderBarComponent implements OnInit {
     private mdIconRegistry: MdIconRegistry,
     private sanitizer: DomSanitizer,
     private cookieService: CookieService,
+    private authService: AuthService,
   ) {}
 
   ngOnInit() {
@@ -52,10 +56,18 @@ export class HeaderBarComponent implements OnInit {
     );
     this.appName = this.config.appName;
 
-    let userClaims = this.cookieService.get("ka_claims")
+    this.authService.loggedIn().subscribe(loggedIn => { this.loggedIn = loggedIn; });
+
+    let userClaims = this.cookieService.get("ka_claims");
     if (userClaims) {
-      this.loggedIn = true;
+      this.user = JSON.parse(atob(userClaims));
     }
+  }
+
+  logout() {
+    this.loggedIn = false;
+    this.user = {};
+    this.authService.logout();
   }
 
   searchCharts(input: HTMLInputElement): void {

--- a/src/ui/src/app/header-bar/header-bar.component.ts
+++ b/src/ui/src/app/header-bar/header-bar.component.ts
@@ -5,6 +5,7 @@ import { MenuService } from '../shared/services/menu.service';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MdIconRegistry } from '@angular/material';
 import { MdSnackBar } from '@angular/material';
+import { CookieService } from 'ngx-cookie';
 
 @Component({
   selector: 'app-header-bar',
@@ -15,6 +16,8 @@ import { MdSnackBar } from '@angular/material';
   inputs: ['showSearch', 'transparent']
 })
 export class HeaderBarComponent implements OnInit {
+  // public loggedIn
+  public loggedIn: boolean;
   // Show search form by default
   public showSearch: boolean = true;
   // Set the background as transparent
@@ -29,7 +32,8 @@ export class HeaderBarComponent implements OnInit {
     public config: ConfigService,
     private menuService: MenuService,
     private mdIconRegistry: MdIconRegistry,
-    private sanitizer: DomSanitizer
+    private sanitizer: DomSanitizer,
+    private cookieService: CookieService,
   ) {}
 
   ngOnInit() {
@@ -47,6 +51,11 @@ export class HeaderBarComponent implements OnInit {
       this.sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/search.svg')
     );
     this.appName = this.config.appName;
+
+    let userClaims = this.cookieService.get("ka_claims")
+    if (userClaims) {
+      this.loggedIn = true;
+    }
   }
 
   searchCharts(input: HTMLInputElement): void {

--- a/src/ui/src/app/shared/services/auth.service.ts
+++ b/src/ui/src/app/shared/services/auth.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { ConfigService } from './config.service';
+import { CookieService } from 'ngx-cookie';
+import { Router } from '@angular/router';
+
+import { Observable } from 'rxjs';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/find';
+import 'rxjs/add/operator/map';
+
+import { Http, Response } from '@angular/http';
+
+/* TODO, This is a mocked class. */
+@Injectable()
+export class AuthService {
+  hostname: string;
+
+  constructor(
+    private http: Http,
+    private config: ConfigService,
+    private cookieService: CookieService,
+    private router: Router,
+  ) {
+    this.hostname = config.backendHostname;
+  }
+
+  /**
+   * Check if logged in on the API server
+   * 
+   * @return {Observable} An observable boolean that will be true if logged in or if auth is disabled
+   */
+  loggedIn(): Observable<boolean> {
+    return this.http.get(`${this.hostname}/auth/verify`, {withCredentials: true})
+      .map((res: Response) => { return res.ok; })
+      .catch(res => {
+        if (res.status == 404) {
+          // If 404, authentication is disabled on the API server and we are considered logged in
+          return Observable.of(true);
+        } else {
+          return Observable.of(false);
+        }
+      });
+  }
+
+  /**
+   * Logs user out
+   */
+  logout() {
+    this.cookieService.remove('ka_claims');
+    this.http.delete(`${this.hostname}/auth/logout`, {withCredentials: true}).subscribe();
+  }
+}

--- a/src/ui/src/app/shared/services/deployments.service.ts
+++ b/src/ui/src/app/shared/services/deployments.service.ts
@@ -22,14 +22,14 @@ export class DeploymentsService {
   }
 
   getDeployments(): Observable<Deployment[]> {
-      return this.http.get(`${this.hostname}/v1/releases`)
+      return this.http.get(`${this.hostname}/v1/releases`, {withCredentials: true})
                     .map((response) => {
                       return this.extractData(response, [])
                     }).catch(this.handleError);
   }
 
   getDeployment(deploymentName: string): Observable<Deployment> {
-      return this.http.get(`${this.hostname}/v1/releases/${deploymentName}`)
+      return this.http.get(`${this.hostname}/v1/releases/${deploymentName}`, {withCredentials: true})
                     .map((response) => {
                       return this.extractData(response, [])
                     }).catch(this.handleError);
@@ -37,13 +37,13 @@ export class DeploymentsService {
 
   installDeployment(chartID: string, version: string, namespace: string): Observable<Deployment> {
       var params = { "chartId": chartID, "chartVersion": version, "namespace": namespace }
-      return this.http.post(`${this.hostname}/v1/releases`, params)
+      return this.http.post(`${this.hostname}/v1/releases`, params, {withCredentials: true})
                     .map(this.extractData)
                     .catch(this.handleError);
   }
 
   deleteDeployment(deploymentName: string): Observable<Deployment> {
-    return this.http.delete(`${this.hostname}/v1/releases/${deploymentName}`)
+    return this.http.delete(`${this.hostname}/v1/releases/${deploymentName}`, {withCredentials: true})
                     .map(this.extractData)
                     .catch(this.handleError);
   }

--- a/src/ui/src/app/shared/services/repos.service.ts
+++ b/src/ui/src/app/shared/services/repos.service.ts
@@ -49,7 +49,7 @@ export class ReposService {
    * @return {Observable} An observable of the deleted repo
    */
   deleteRepo(repoName: string): Observable<Repo> {
-    return this.http.delete(`${this.hostname}/v1/repos/${repoName}`)
+    return this.http.delete(`${this.hostname}/v1/repos/${repoName}`, {withCredentials: true})
                     .map(this.extractData)
                     .catch(this.handleError);
   }

--- a/src/ui/src/app/shared/services/repos.service.ts
+++ b/src/ui/src/app/shared/services/repos.service.ts
@@ -38,7 +38,7 @@ export class ReposService {
    * @return {Observable} An observable repo
    */
   createRepo(params: RepoAttributes): Observable<Repo> {
-    return this.http.post(`${this.hostname}/v1/repos`, params)
+    return this.http.post(`${this.hostname}/v1/repos`, params, {withCredentials: true})
                   .map(this.extractData)
                   .catch(this.handleError);
   }

--- a/src/ui/yarn.lock
+++ b/src/ui/yarn.lock
@@ -3118,6 +3118,10 @@ ngx-clipboard@^8.0.3:
   dependencies:
     ngx-window-token "0.0.2"
 
+ngx-cookie@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ngx-cookie/-/ngx-cookie-1.0.0.tgz#004fc653febd849b4dd3ee2c63c4cf171f464da9"
+
 ngx-window-token@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/ngx-window-token/-/ngx-window-token-0.0.2.tgz#680ee986bbe6f95d07daadf154c0ecf35e589920"


### PR DESCRIPTION
Protects API methods for:
- adding and delete repos
- viewing, creating and deleting Helm releases

The JWT is stored in an httpOnly cookie and is only valid for 2 hours. A second cookie, accessible via JS, is used in the UI to determine if the user is logged in or not.