### PR TITLE
fixes fetching relative chart urls from index

### DIFF
--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -177,9 +177,8 @@ func (c *cachedCharts) Refresh() error {
 		defer close(ch)
 
 		// 3.1 - parallellize processing
-		repoURL, _ := url.Parse(repo.URL)
 		for _, chart := range charts {
-			go processChartMetadata(chart, repoURL, ch)
+			go processChartMetadata(chart, repo.URL, ch)
 		}
 		// 3.2 Channel drain
 		for range charts {
@@ -208,7 +207,7 @@ type chanItem struct {
 // Counting semaphore, 25 downloads max in paralell
 var tokens = make(chan struct{}, 15)
 
-func processChartMetadata(chart *swaggermodels.ChartPackage, repoURL *url.URL, out chan<- chanItem) {
+func processChartMetadata(chart *swaggermodels.ChartPackage, repoURL string, out chan<- chanItem) {
 	tokens <- struct{}{}
 	// Semaphore control channel
 	defer func() {

--- a/src/api/data/cache/cache_test.go
+++ b/src/api/data/cache/cache_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"errors"
-	"net/url"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -81,7 +80,7 @@ func TestCachedChartsRefresh(t *testing.T) {
 	// Stubs Download and processing
 	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
 	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
-	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL *url.URL) error { return nil }
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL string) error { return nil }
 
 	DownloadAndProcessChartIconOrig := charthelper.DownloadAndProcessChartIcon
 	defer func() { charthelper.DownloadAndProcessChartIcon = DownloadAndProcessChartIconOrig }()
@@ -121,7 +120,7 @@ func TestCachedChartsRefreshErrorDownloadingPackage(t *testing.T) {
 	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
 	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
 	knownError := errors.New("error on DownloadAndExtractChartTarball")
-	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL *url.URL) error {
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL string) error {
 		return knownError
 	}
 

--- a/src/api/data/cache/cache_test.go
+++ b/src/api/data/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/arschles/assert"
@@ -80,7 +81,7 @@ func TestCachedChartsRefresh(t *testing.T) {
 	// Stubs Download and processing
 	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
 	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
-	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage) error { return nil }
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL *url.URL) error { return nil }
 
 	DownloadAndProcessChartIconOrig := charthelper.DownloadAndProcessChartIcon
 	defer func() { charthelper.DownloadAndProcessChartIcon = DownloadAndProcessChartIconOrig }()
@@ -120,7 +121,7 @@ func TestCachedChartsRefreshErrorDownloadingPackage(t *testing.T) {
 	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
 	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
 	knownError := errors.New("error on DownloadAndExtractChartTarball")
-	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage) error {
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL *url.URL) error {
 		return knownError
 	}
 

--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -24,7 +24,7 @@ const defaultTimeout time.Duration = 10 * time.Second
 
 // DownloadAndExtractChartTarball the chart tar file linked by metadata.Urls and store
 // the wanted files (i.e README.md) under chartDataDir
-var DownloadAndExtractChartTarball = func(chart *models.ChartPackage, repoURL *url.URL) (err error) {
+var DownloadAndExtractChartTarball = func(chart *models.ChartPackage, repoURL string) (err error) {
 	if err := ensureChartDataDir(chart); err != nil {
 		return err
 	}
@@ -55,14 +55,15 @@ var tarballExists = func(chart *models.ChartPackage) bool {
 
 // Downloads the tar.gz file associated with the chart version exposed by the index
 // in order to extract specific files for caching
-var downloadTarball = func(chart *models.ChartPackage, repoURL *url.URL) error {
+var downloadTarball = func(chart *models.ChartPackage, repoURL string) error {
 	source := chart.Urls[0]
 	if _, err := url.ParseRequestURI(source); err != nil {
 		// If the chart URL is not absolute, join with repo URL. It's fine if the
 		// URL we build here is invalid as we can catch this error when actually
 		// making the request
-		repoURL.Path = path.Join(repoURL.Path, source)
-		source = repoURL.String()
+		u, _ := url.Parse(repoURL)
+		u.Path = path.Join(u.Path, source)
+		source = u.String()
 	}
 
 	destination := TarballPath(chart)

--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -58,7 +58,9 @@ var tarballExists = func(chart *models.ChartPackage) bool {
 var downloadTarball = func(chart *models.ChartPackage, repoURL *url.URL) error {
 	source := chart.Urls[0]
 	if _, err := url.ParseRequestURI(source); err != nil {
-		// If the chart URL is not absolute, join with repo URL
+		// If the chart URL is not absolute, join with repo URL. It's fine if the
+		// URL we build here is invalid as we can catch this error when actually
+		// making the request
 		repoURL.Path = path.Join(repoURL.Path, source)
 		source = repoURL.String()
 	}

--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -22,7 +24,7 @@ const defaultTimeout time.Duration = 10 * time.Second
 
 // DownloadAndExtractChartTarball the chart tar file linked by metadata.Urls and store
 // the wanted files (i.e README.md) under chartDataDir
-var DownloadAndExtractChartTarball = func(chart *models.ChartPackage) (err error) {
+var DownloadAndExtractChartTarball = func(chart *models.ChartPackage, repoURL *url.URL) (err error) {
 	if err := ensureChartDataDir(chart); err != nil {
 		return err
 	}
@@ -34,7 +36,7 @@ var DownloadAndExtractChartTarball = func(chart *models.ChartPackage) (err error
 	}()
 
 	if !tarballExists(chart) {
-		if err := downloadTarball(chart); err != nil {
+		if err := downloadTarball(chart, repoURL); err != nil {
 			return err
 		}
 	}
@@ -53,8 +55,14 @@ var tarballExists = func(chart *models.ChartPackage) bool {
 
 // Downloads the tar.gz file associated with the chart version exposed by the index
 // in order to extract specific files for caching
-var downloadTarball = func(chart *models.ChartPackage) error {
+var downloadTarball = func(chart *models.ChartPackage, repoURL *url.URL) error {
 	source := chart.Urls[0]
+	if _, err := url.ParseRequestURI(source); err != nil {
+		// If the chart URL is not absolute, join with repo URL
+		repoURL.Path = path.Join(repoURL.Path, source)
+		source = repoURL.String()
+	}
+
 	destination := TarballPath(chart)
 
 	// Create output

--- a/src/api/data/cache/charthelper/chart_package_helper_test.go
+++ b/src/api/data/cache/charthelper/chart_package_helper_test.go
@@ -3,7 +3,6 @@ package charthelper
 import (
 	"errors"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 	"github.com/kubernetes-helm/monocular/src/api/swagger/models"
 )
 
-var repoURL, _ = url.Parse("http://storage.googleapis.com/kubernetes-charts/")
+var repoURL = "http://storage.googleapis.com/kubernetes-charts/"
 
 func TestDownloadAndExtractChartTarballOk(t *testing.T) {
 	chart, err := getTestChart()
@@ -44,7 +43,7 @@ func TestDownloadAndExtractChartTarballErrorDownload(t *testing.T) {
 	// Stubs
 	downloadTarballOrig := downloadTarball
 	defer func() { downloadTarball = downloadTarballOrig }()
-	downloadTarball = func(chart *models.ChartPackage, url *url.URL) error { return errors.New("Can't download") }
+	downloadTarball = func(chart *models.ChartPackage, url string) error { return errors.New("Can't download") }
 	tarballExistsOrig := tarballExists
 	defer func() { tarballExists = tarballExistsOrig }()
 	tarballExists = func(chart *models.ChartPackage) bool { return false }


### PR DESCRIPTION
Helm supports repository indexes that use relative URLs to chart
packages (formed by omitting the --url flag in `helm repo index`). This
patch enables Monocular to do the same.

Fixes #387