### PR TITLE
Adds GH login to user collection

### DIFF
--- a/src/api/handlers/auth.go
+++ b/src/api/handlers/auth.go
@@ -108,7 +108,7 @@ func (a *AuthHandlers) GithubCallback(w http.ResponseWriter, r *http.Request) {
 
 	db, closer := a.dbSession.DB()
 	defer closer()
-	if err := models.CreateUser(db, &models.User{Name: user.GetName(), Email: userEmail}); err != nil {
+	if err := models.CreateUser(db, &models.User{Login: user.GetLogin(), Name: user.GetName(), Email: userEmail}); err != nil {
 		errorResponse(w, http.StatusInternalServerError, "unable to save user")
 		return
 	}

--- a/src/api/handlers/auth.go
+++ b/src/api/handlers/auth.go
@@ -114,7 +114,7 @@ func (a *AuthHandlers) GithubCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch from DB to get ID
-	u, err := models.GetUserByEmail(db, userEmail)
+	u, err := models.GetUserByLogin(db, user.GetLogin())
 
 	claims := models.UserClaims{
 		User: u,

--- a/src/api/middleware/authgate_test.go
+++ b/src/api/middleware/authgate_test.go
@@ -52,7 +52,7 @@ func TestAuthGateDisabled(t *testing.T) {
 
 func generateClaims(expiresAt time.Time) jwt.Claims {
 	return models.UserClaims{
-		User: &models.User{Name: "Jon Snow", Email: "jonsnow@winteriscoming.io"},
+		User: &models.User{Login: "jon.snow", Name: "Jon Snow", Email: "jonsnow@winteriscoming.io"},
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: expiresAt.Unix(),
 			Issuer:    "lyanna.stark",

--- a/src/api/models/mockstore.go
+++ b/src/api/models/mockstore.go
@@ -76,7 +76,7 @@ type mockQuery struct {
 var MockRepos = OfficialRepos
 
 // MockUser contains the mock user returned by the database
-var MockUser = &User{Name: "Rick Sanchez", Email: "rick@sanchez.com"}
+var MockUser = &User{Login: "rick.sanchez", Name: "Rick Sanchez", Email: "rick@sanchez.com"}
 
 func (q mockQuery) All(result interface{}) error {
 	if q.c.Empty {

--- a/src/api/models/user.go
+++ b/src/api/models/user.go
@@ -31,18 +31,18 @@ const UserKey contextKey = 0
 const UsersCollection = "users"
 
 // CreateUser takes a User object and saves it to the database
-// Users with the same email are updated
+// Users with the same login id are updated
 func CreateUser(db datastore.Database, user *User) error {
 	c := db.C(UsersCollection)
-	_, err := c.Upsert(bson.M{"email": user.Email}, user)
+	_, err := c.Upsert(bson.M{"login": user.Login}, user)
 	return err
 }
 
-// GetUserByEmail finds a user given an email
-func GetUserByEmail(db datastore.Database, email string) (*User, error) {
+// GetUserByLogin finds a user given the login id
+func GetUserByLogin(db datastore.Database, login string) (*User, error) {
 	c := db.C(UsersCollection)
 	var user User
-	err := c.Find(bson.M{"email": email}).One(&user)
+	err := c.Find(bson.M{"login": login}).One(&user)
 	if err != nil {
 		return nil, err
 	}

--- a/src/api/models/user.go
+++ b/src/api/models/user.go
@@ -9,6 +9,7 @@ import (
 // User describes a user
 type User struct {
 	ID      bson.ObjectId   `json:"id" bson:"_id,omitempty"`
+	Login   string          `json:"login"`
 	Name    string          `json:"name"`
 	Email   string          `json:"email"`
 	starred []bson.ObjectId `bson:"starred"`

--- a/src/api/models/user_test.go
+++ b/src/api/models/user_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCreateUser(t *testing.T) {
-	user := &User{Name: "Rick Sanchez", Email: "rick@sanchez.com"}
+	user := &User{Login: "rick.sanchez", Name: "Rick Sanchez", Email: "rick@sanchez.com"}
 	tests := []struct {
 		name      string
 		expectErr bool

--- a/src/api/models/user_test.go
+++ b/src/api/models/user_test.go
@@ -24,7 +24,7 @@ func TestCreateUser(t *testing.T) {
 	}
 }
 
-func TestGetUserByEmail(t *testing.T) {
+func TestGetUserByLogin(t *testing.T) {
 	tests := []struct {
 		name      string
 		expected  *User
@@ -35,7 +35,7 @@ func TestGetUserByEmail(t *testing.T) {
 	}
 	for _, tt := range tests {
 		db, _ := NewMockSession(MockDBConfig{WantErr: tt.expectErr}).DB()
-		actual, err := GetUserByEmail(db, "rick@sanchez.com")
+		actual, err := GetUserByLogin(db, "rick.sanchez")
 		assert.Equal(t, err != nil, tt.expectErr, "error")
 		assert.Equal(t, actual, tt.expected, "repo")
 	}


### PR DESCRIPTION
**Changes**
- oauth: save github login id to user collection
- oauth: lookup the gh login id while registering/logging in a user
  Unlike the primary email the github login id is immutable and is
  therefore a better candidate to perform a user lookup
