### PR TITLE
add option to specify tiller host

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -30,6 +30,9 @@ tillerPortForward: true
 # Specify a different namespace where to locate tiller-deploy
 tillerNamespace: kube-system
 
+# Specify a custom host for Tiller
+# tillerHost: localhost:44134
+
 # Configure cache refresh interval in sec
 cacheRefreshInterval: 3600
 

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -37,6 +37,7 @@ type Configuration struct {
 	OAuthConfig          oauthConfig      `yaml:"oauthConfig"`
 	SigningKey           string           `yaml:"signingKey"`
 	TillerNamespace      string           `yaml:"tillerNamespace"`
+	TillerHost           string           `yaml:"tillerHost"`
 	Initialized          bool
 }
 

--- a/src/api/data/helm/client/client.go
+++ b/src/api/data/helm/client/client.go
@@ -42,8 +42,12 @@ func (c *helmClient) initialize() (*helm.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	tillerHost := conf.TillerHost
 	tillerNamespace := conf.TillerNamespace
-	var tillerHost = fmt.Sprintf("%s.%s:%d", tillerServiceName, tillerNamespace, tillerPort)
+	if tillerHost == "" {
+		tillerHost = fmt.Sprintf("%s.%s:%d", tillerServiceName, tillerNamespace, tillerPort)
+	}
 
 	if c.portForward {
 		config, kubeClient, err := getKubeClient("")


### PR DESCRIPTION
This is useful for development purposes where you may want to run a local tiller
instance, or if you have installed tiller in a non-standard location.