### PR TITLE
Small typo fix

### DIFF
--- a/deployment/monocular/README.md
+++ b/deployment/monocular/README.md
@@ -67,7 +67,7 @@ $ helm install monocular/monocular --set api.config.tillerNamespace=YOUR_NAMESPA
 If you want to run Monocular without giving the option to install and manage charts in your cluster, similar to [KubeApps](https://kubeapps.com) you can configure `api.config.releasesEnabled`:
 
 ```console
-$ helm install monocular/monocular --set api.config.releasedEnabled=false
+$ helm install monocular/monocular --set api.config.releasesEnabled=false
 ```
 
 ### Configuring chart repositories


### PR DESCRIPTION
Found this small typo while trying to deploy monocular with helm and did not know why I still received a warning regarding releases being enabled. Of course, this was due to copy-pasting the command. 