### PR TITLE
chart-repo-sync: fix repo urls under a subpath

### DIFF
--- a/src/api/cmd/chart-repo-sync/sync.go
+++ b/src/api/cmd/chart-repo-sync/sync.go
@@ -154,22 +154,23 @@ func syncRepo(repoName, repoURL string) error {
 }
 
 func fetchRepoIndex(repoURL *url.URL) (*helmrepo.IndexFile, error) {
+	// use a copy of the URL struct so we don't modify the original
 	indexURL := *repoURL
-	indexURL.Path = "/index.yaml"
+	indexURL.Path = path.Join(indexURL.Path, "index.yaml")
 	req, err := http.NewRequest("GET", indexURL.String(), nil)
 	req.Header.Set("User-Agent", userAgent)
 	if err != nil {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("could not build repo index request")
+		log.WithFields(log.Fields{"url": req.URL.String()}).WithError(err).Error("could not build repo index request")
 		return nil, err
 	}
 	res, err := netClient.Do(req)
 	if err != nil {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("error requesting repo index")
+		log.WithFields(log.Fields{"url": req.URL.String()}).WithError(err).Error("error requesting repo index")
 		return nil, err
 	}
 
 	if res.StatusCode != http.StatusOK {
-		log.WithFields(log.Fields{"url": repoURL}).WithError(err).Error("error requesting repo index, are you sure this is a chart repository?")
+		log.WithFields(log.Fields{"url": req.URL.String(), "status": res.StatusCode}).Error("error requesting repo index, are you sure this is a chart repository?")
 		return nil, errors.New("repo index request failed")
 	}
 

--- a/src/api/cmd/chart-repo-sync/sync_test.go
+++ b/src/api/cmd/chart-repo-sync/sync_test.go
@@ -46,6 +46,11 @@ func (h *goodHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if strings.HasPrefix(req.URL.Path, "//") {
 		w.WriteHeader(500)
 	}
+	// If subpath repo URL test, check that index.yaml is correctly added to the
+	// subpath
+	if req.URL.Host == "subpath.test" && req.URL.Path != "/subpath/index.yaml" {
+		w.WriteHeader(500)
+	}
 	// Ensure we're sending the right User-Agent
 	if !strings.Contains(req.Header.Get("User-Agent"), "chart-repo-sync") {
 		w.WriteHeader(500)
@@ -120,6 +125,7 @@ func Test_fetchRepoIndex(t *testing.T) {
 		{"valid HTTP URL", "http://my.examplerepo.com"},
 		{"valid HTTPS URL", "https://my.examplerepo.com"},
 		{"valid trailing URL", "https://my.examplerepo.com/"},
+		{"valid subpath URL", "https://subpath.test/subpath/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug that meant chart-repo-sync wouldn't work with chart
repositories under a sub directory (e.g.
https://charts.bitnami.com/incubator).