### PR TITLE
refresh single chart draft

### DIFF
--- a/src/api/data/cache/cache_test.go
+++ b/src/api/data/cache/cache_test.go
@@ -102,10 +102,22 @@ func TestCachedChartsRefreshChart(t *testing.T) {
 	defer func() { charthelper.DownloadAndProcessChartIcon = DownloadAndProcessChartIconOrig }()
 	charthelper.DownloadAndProcessChartIcon = func(chart *swaggermodels.ChartPackage) error { return nil }
 
-	// EO stubs
-
 	err := chartsImplementation.RefreshChart("stable", "datadog")
 	assert.NoErr(t, err)
+}
+
+func TestCachedChartsRefreshChartRepoNotFound(t *testing.T) {
+	// Stubs Download and processing
+	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
+	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL string) error { return nil }
+
+	DownloadAndProcessChartIconOrig := charthelper.DownloadAndProcessChartIcon
+	defer func() { charthelper.DownloadAndProcessChartIcon = DownloadAndProcessChartIconOrig }()
+	charthelper.DownloadAndProcessChartIcon = func(chart *swaggermodels.ChartPackage) error { return nil }
+
+	err := chartsImplementation.RefreshChart("stable", "inexistant chart")
+	assert.Err(t, err, errors.New("no chart \"inexistant chart\" found for repo stable\n"))
 }
 
 func TestCachedChartsRefreshErrorPropagation(t *testing.T) {

--- a/src/api/data/cache/cache_test.go
+++ b/src/api/data/cache/cache_test.go
@@ -92,6 +92,22 @@ func TestCachedChartsRefresh(t *testing.T) {
 	assert.NoErr(t, err)
 }
 
+func TestCachedChartsRefreshChart(t *testing.T) {
+	// Stubs Download and processing
+	DownloadAndExtractChartTarballOrig := charthelper.DownloadAndExtractChartTarball
+	defer func() { charthelper.DownloadAndExtractChartTarball = DownloadAndExtractChartTarballOrig }()
+	charthelper.DownloadAndExtractChartTarball = func(chart *swaggermodels.ChartPackage, repoURL string) error { return nil }
+
+	DownloadAndProcessChartIconOrig := charthelper.DownloadAndProcessChartIcon
+	defer func() { charthelper.DownloadAndProcessChartIcon = DownloadAndProcessChartIconOrig }()
+	charthelper.DownloadAndProcessChartIcon = func(chart *swaggermodels.ChartPackage) error { return nil }
+
+	// EO stubs
+
+	err := chartsImplementation.RefreshChart("stable", "datadog")
+	assert.NoErr(t, err)
+}
+
 func TestCachedChartsRefreshErrorPropagation(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/src/api/data/cache/repohelper/repo_helper.go
+++ b/src/api/data/cache/repohelper/repo_helper.go
@@ -1,0 +1,45 @@
+package repohelper
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/kubernetes-helm/monocular/src/api/data/helpers"
+	"github.com/kubernetes-helm/monocular/src/api/models"
+	swaggermodels "github.com/kubernetes-helm/monocular/src/api/swagger/models"
+	"github.com/kubernetes-helm/monocular/src/api/version"
+)
+
+// GetRepoIndexFile Get the charts from the index file
+var GetChartsFromRepoIndexFile = func(repo *models.Repo) ([]*swaggermodels.ChartPackage, error) {
+
+	u, _ := url.Parse(repo.URL)
+	u.Path = path.Join(u.Path, "index.yaml")
+
+	// 1 - Download repo index
+	var client http.Client
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", version.GetUserAgent())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2 - Parse repo index
+	charts, err := helpers.ParseYAMLRepo(body, repo.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return charts, nil
+}

--- a/src/api/data/cache/repohelper/repo_helper.go
+++ b/src/api/data/cache/repohelper/repo_helper.go
@@ -14,7 +14,6 @@ import (
 
 // GetRepoIndexFile Get the charts from the index file
 var GetChartsFromRepoIndexFile = func(repo *models.Repo) ([]*swaggermodels.ChartPackage, error) {
-
 	u, _ := url.Parse(repo.URL)
 	u.Path = path.Join(u.Path, "index.yaml")
 

--- a/src/api/data/charts.go
+++ b/src/api/data/charts.go
@@ -21,4 +21,5 @@ type Charts interface {
 	Search(params charts.SearchChartsParams) ([]*models.ChartPackage, error)
 	// Refresh freshens charts data
 	Refresh() error
+	RefreshChart(Repo string, ChartName string) error
 }

--- a/src/api/handlers/charts/charts.go
+++ b/src/api/handlers/charts/charts.go
@@ -65,9 +65,11 @@ func (c *ChartHandlers) RefreshChart(w http.ResponseWriter, req *http.Request, p
 	err = c.chartsImplementation.RefreshChart(params["repo"], params["chartName"])
 
 	if err != nil {
-		log.Printf("data.chartsapi.RefreshChart(%s, %s) error (%s)", params["repo"], params["chartName"], err)
-		notFound(w, ChartVersionResourceName)
+		message := fmt.Sprintf("data.chartsapi.RefreshChart(%s, %s) error (%s)", params["repo"], params["chartName"], err)
+		log.Printf(message)
+		renderer.Render.JSON(w, http.StatusBadRequest, models.Error{Code: pointerto.Int64(http.StatusBadRequest), Message: &message})
 		return
+
 	}
 	payload := handlers.DataResourceBody(chartResource)
 	renderer.Render.JSON(w, http.StatusOK, payload)

--- a/src/api/handlers/charts/charts_test.go
+++ b/src/api/handlers/charts/charts_test.go
@@ -208,6 +208,23 @@ func TestGetChartsInRepo404(t *testing.T) {
 	testutil.AssertErrBodyData(t, http.StatusNotFound, ChartResourceName+"s", httpBody)
 }
 
+func TestRefreshChart200(t *testing.T) {
+	req, err := http.NewRequest("POST", "/v1/charts/"+testutil.RepoName+"/"+testutil.ChartName+"/refresh", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	//chartHandlers.GetChartsInRepo(res, req, handlers.Params{"repo": testutil.RepoName})
+	chartHandlers.RefreshChart(res, req, handlers.Params{"repo": testutil.RepoName, "chartName": testutil.ChartName})
+	assert.Equal(t, res.Code, http.StatusOK, "expect a 200 response code")
+}
+func TestRefreshChart404(t *testing.T) {
+	req, err := http.NewRequest("POST", "/v1/charts/"+testutil.RepoName+"/"+testutil.ChartName+"/refresh", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+	//chartHandlers.GetChartsInRepo(res, req, handlers.Params{"repo": testutil.RepoName})
+	chartHandlers.RefreshChart(res, req, handlers.Params{"repo": testutil.RepoName, "chartName": "inexistant chart"})
+	assert.Equal(t, res.Code, http.StatusNotFound, "expect a 404 response code")
+}
+
 func TestChartHTTPBody(t *testing.T) {
 	w := httptest.NewRecorder()
 	chart, err := chartsImplementation.ChartFromRepo(testutil.RepoName, testutil.ChartName)

--- a/src/api/handlers/charts/charts_test.go
+++ b/src/api/handlers/charts/charts_test.go
@@ -212,17 +212,31 @@ func TestRefreshChart200(t *testing.T) {
 	req, err := http.NewRequest("POST", "/v1/charts/"+testutil.RepoName+"/"+testutil.ChartName+"/refresh", nil)
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
-	//chartHandlers.GetChartsInRepo(res, req, handlers.Params{"repo": testutil.RepoName})
 	chartHandlers.RefreshChart(res, req, handlers.Params{"repo": testutil.RepoName, "chartName": testutil.ChartName})
 	assert.Equal(t, res.Code, http.StatusOK, "expect a 200 response code")
 }
+
 func TestRefreshChart404(t *testing.T) {
 	req, err := http.NewRequest("POST", "/v1/charts/"+testutil.RepoName+"/"+testutil.ChartName+"/refresh", nil)
 	assert.NoErr(t, err)
 	res := httptest.NewRecorder()
-	//chartHandlers.GetChartsInRepo(res, req, handlers.Params{"repo": testutil.RepoName})
 	chartHandlers.RefreshChart(res, req, handlers.Params{"repo": testutil.RepoName, "chartName": "inexistant chart"})
 	assert.Equal(t, res.Code, http.StatusNotFound, "expect a 404 response code")
+}
+
+func TestRefreshChart400(t *testing.T) {
+	req, err := http.NewRequest("POST", "/v1/charts/"+testutil.RepoName+"/"+testutil.ChartName+"/refresh", nil)
+	assert.NoErr(t, err)
+	res := httptest.NewRecorder()
+
+	chImplementation := mocks.NewMockCharts(mocks.MockedMethods{
+		RefreshChart: func(repoName string, chartName string) error {
+			return errors.New("error refreshing chart")
+		},
+	})
+
+	NewChartHandlers(dbSession, chImplementation).RefreshChart(res, req, handlers.Params{"repo": testutil.RepoName, "chartName": testutil.ChartName})
+	assert.Equal(t, res.Code, http.StatusBadRequest, "expect a 400 response code")
 }
 
 func TestChartHTTPBody(t *testing.T) {

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -84,6 +84,7 @@ func setupRoutes(conf config.Configuration, chartsImplementation data.Charts, he
 	apiv1.Methods("GET").Path("/charts/search").HandlerFunc(chartHandlers.SearchCharts)
 	apiv1.Methods("GET").Path("/charts/{repo}").Handler(handlers.WithParams(chartHandlers.GetChartsInRepo))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}").Handler(handlers.WithParams(chartHandlers.GetChart))
+	apiv1.Methods("POST").Path("/charts/{repo}/{chartName}/refresh").Handler(handlers.WithParams(chartHandlers.RefreshChart))
 
 	// Chart Version routes
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}/versions").Handler(handlers.WithParams(chartHandlers.GetChartVersions))

--- a/src/api/mocks/charts.go
+++ b/src/api/mocks/charts.go
@@ -145,6 +145,9 @@ func (c *mockCharts) Search(params chartsapi.SearchChartsParams) ([]*models.Char
 func (c *mockCharts) Refresh() error {
 	return nil
 }
+func (c *mockCharts) RefreshChart(repoName string, chartName string) error {
+	return nil
+}
 
 // getMockRepo is a convenience that loads a yaml repo from the filesystem
 func getMockRepo(repo string) ([]byte, error) {

--- a/src/api/mocks/charts.go
+++ b/src/api/mocks/charts.go
@@ -13,8 +13,9 @@ import (
 
 // MockedMethods contains pointers to mocked implementations of methods
 type MockedMethods struct {
-	All    func() ([]*models.ChartPackage, error)
-	Search func(params chartsapi.SearchChartsParams) ([]*models.ChartPackage, error)
+	All          func() ([]*models.ChartPackage, error)
+	Search       func(params chartsapi.SearchChartsParams) ([]*models.ChartPackage, error)
+	RefreshChart func(repoName string, chartName string) error
 }
 
 // mockCharts fulfills the data.Charts interface
@@ -146,6 +147,9 @@ func (c *mockCharts) Refresh() error {
 	return nil
 }
 func (c *mockCharts) RefreshChart(repoName string, chartName string) error {
+	if c.mockedMethods.RefreshChart != nil {
+		return c.mockedMethods.RefreshChart(repoName, chartName)
+	}
 	return nil
 }
 

--- a/src/api/mocks/charts_test.go
+++ b/src/api/mocks/charts_test.go
@@ -105,6 +105,11 @@ func TestMockChartsAllFromRepo(t *testing.T) {
 	assert.True(t, len(noCharts) == 0, "empty charts slice")
 }
 
+func TestMockChartsRefresh(t *testing.T) {
+	err := chartsImplementation.Refresh()
+	assert.NoErr(t, err)
+}
+
 func TestMockChartsRefreshChart(t *testing.T) {
 	err := chartsImplementation.RefreshChart(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)

--- a/src/api/mocks/charts_test.go
+++ b/src/api/mocks/charts_test.go
@@ -104,3 +104,8 @@ func TestMockChartsAllFromRepo(t *testing.T) {
 	assert.ExistsErr(t, err, "sent bogus repo name to GetChartsInRepo")
 	assert.True(t, len(noCharts) == 0, "empty charts slice")
 }
+
+func TestMockChartsRefreshChart(t *testing.T) {
+	err := chartsImplementation.RefreshChart(testutil.RepoName, testutil.ChartName)
+	assert.NoErr(t, err)
+}


### PR DESCRIPTION
Hello there,

I made some changes to support the refresh of a single chart. With this feature, we are able to upload a chart into a chart repo and trigger the refresh in monocular automatically right after, in a programmatic way. To resume, this provides a way to see the chart in monocular immediately after it was uploaded in the repo.

an example call to the api would be: 
curl -X POST http://localhost:8080/v1/charts/incubator/zookeeper/refresh

This is a first draft. If the feature is ok for you, I can proceed with polishing the PR's code.

Thanks