### PR TITLE
bug fixes: in memory allCharts map was not updated on chart refresh

### DIFF
--- a/src/api/data/charts.go
+++ b/src/api/data/charts.go
@@ -21,5 +21,6 @@ type Charts interface {
 	Search(params charts.SearchChartsParams) ([]*models.ChartPackage, error)
 	// Refresh freshens charts data
 	Refresh() error
-	RefreshChart(Repo string, ChartName string) error
+	RefreshChart(Repo string, chartName string) error
+	DeleteChart(Repo string, chartName string, version string) error
 }

--- a/src/api/mocks/charts.go
+++ b/src/api/mocks/charts.go
@@ -16,6 +16,7 @@ type MockedMethods struct {
 	All          func() ([]*models.ChartPackage, error)
 	Search       func(params chartsapi.SearchChartsParams) ([]*models.ChartPackage, error)
 	RefreshChart func(repoName string, chartName string) error
+	DeleteChart  func(repoName string, chartName string, version string) error
 }
 
 // mockCharts fulfills the data.Charts interface
@@ -146,9 +147,17 @@ func (c *mockCharts) Search(params chartsapi.SearchChartsParams) ([]*models.Char
 func (c *mockCharts) Refresh() error {
 	return nil
 }
+
 func (c *mockCharts) RefreshChart(repoName string, chartName string) error {
 	if c.mockedMethods.RefreshChart != nil {
 		return c.mockedMethods.RefreshChart(repoName, chartName)
+	}
+	return nil
+}
+
+func (c *mockCharts) DeleteChart(repoName string, chartName string, version string) error {
+	if c.mockedMethods.DeleteChart != nil {
+		return c.mockedMethods.DeleteChart(repoName, chartName, version)
 	}
 	return nil
 }

--- a/src/api/mocks/charts_test.go
+++ b/src/api/mocks/charts_test.go
@@ -114,3 +114,8 @@ func TestMockChartsRefreshChart(t *testing.T) {
 	err := chartsImplementation.RefreshChart(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
 }
+
+func TestMockChartsDeleteChart(t *testing.T) {
+	err := chartsImplementation.DeleteChart(testutil.RepoName, testutil.ChartName, testutil.ChartVersionString)
+	assert.NoErr(t, err)
+}


### PR DESCRIPTION
- charts in memory were not updated because I was not comparing the string contents
- updates were done on existing versions but not on new versions, which is useless since most of the time we upload a new version.