### PR TITLE
Refresh all the repos

### DIFF
--- a/src/api/data/cache/auto_refresher_test.go
+++ b/src/api/data/cache/auto_refresher_test.go
@@ -35,5 +35,5 @@ func TestNewRefreshDataError(t *testing.T) {
 	job := NewRefreshChartsData(chartsImplementation, freshness, "test-run", true)
 	assert.Equal(t, job.FirstRun(), true, "First run")
 	err := job.Do()
-	assert.ExistsErr(t, err, "Error executing refresh")
+	assert.NoErr(t, err)
 }

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -240,7 +240,11 @@ func (c *cachedCharts) Refresh() error {
 	for _, repo := range repos {
 		charts, err := repohelper.GetChartsFromRepoIndexFile(repo)
 		if err != nil {
-			return err
+			log.WithFields(log.Fields{
+				"repo": repo,
+				"error": err,
+			}).Error("error on refresh charts from repo")
+			continue
 		}
 
 		// 3 - Process elements in index

--- a/src/api/data/cache/cache_test.go
+++ b/src/api/data/cache/cache_test.go
@@ -180,7 +180,10 @@ func TestCachedChartsRefreshErrorPropagation(t *testing.T) {
 			chImplementation := NewCachedCharts(models.NewMockSession(models.MockDBConfig{}))
 			models.MockRepos = tt.repos
 			err := chImplementation.Refresh()
-			assert.ExistsErr(t, err, tt.name)
+			assert.NoErr(t, err)
+			allCharts, err := chImplementation.All()
+			assert.NoErr(t, err)
+			assert.True(t, len(allCharts) == 0, "empty charts slice")
 		})
 	}
 }


### PR DESCRIPTION
Currently if config file have a bad repo and some right repos,
monocualr-api don't get charts from repos and no error message to
user. We should try all the repos.